### PR TITLE
Fix: type 'string' is not assignable to type 'E164Number' #28

### DIFF
--- a/components/ui/phone-input.tsx
+++ b/components/ui/phone-input.tsx
@@ -52,7 +52,7 @@ const PhoneInput: React.ForwardRefExoticComponent<PhoneInputProps> =
            *
            * @param {E164Number | undefined} value - The entered value
            */
-          onChange={(value) => onChange?.(value || "")}
+          onChange={(value) => onChange?.(value || ("" as RPNInput.Value))}
           {...props}
         />
       );


### PR DESCRIPTION
It resolves the build error on your nextjs project caused by the type error. The complete error message is:

`
Types of property 'value' are incompatible. Type 'string' is not assignable to type 'E164Number'
`

Added some basic type conversion to resolve issue #28 