### PR TITLE
Fix: Types of property 'value' are incompatible. Type 'string' is not assignable to type 'E164Number' #28

### DIFF
--- a/components/ui/phone-input.tsx
+++ b/components/ui/phone-input.tsx
@@ -15,7 +15,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { Input, InputProps } from "@/components/ui/input";
+import { Input, type InputProps } from "@/components/ui/input";
 import {
   Popover,
   PopoverContent,
@@ -30,7 +30,7 @@ type PhoneInputProps = Omit<
   "onChange" | "value"
 > &
   Omit<RPNInput.Props<typeof RPNInput.default>, "onChange"> & {
-    onChange?: (value: RPNInput.Value) => void;
+    onChange?: (value: RPNInput.Value | string) => void;
   };
 
 const PhoneInput: React.ForwardRefExoticComponent<PhoneInputProps> =


### PR DESCRIPTION
## Fix: Types of property 'value' are incompatible. Type 'string' is not assignable to type 'E164Number' #28
## It resolves the type error caused in issue #28  .

The Error Message
<mark>
Argument of type 'E164Number | ""' is not assignable to parameter of type 'E164Number'.
Type 'string' is not assignable to type 'E164Number'.
Type 'string' is not assignable to type '{ __tag: "E164Number"; }'.ts(2345)
</mark>

How I Fixed it:
- Added a type string to this line <mark>onChange?: (value: RPNInput.Value | <mark>string</mark>) => void;</mark>
- This will resolve issue #28 
### Others:
- Optimized Imports
<mark>import { Input, type InputProps } from "@/components/ui/input";</mark>

 