### PR TITLE
Fix CommandInput to stay on top of the popover

### DIFF
--- a/components/ui/phone-input.tsx
+++ b/components/ui/phone-input.tsx
@@ -113,9 +113,9 @@ const CountrySelect = ({
       </PopoverTrigger>
       <PopoverContent className="w-[300px] p-0">
         <Command>
+          <CommandInput placeholder="Search country..." />
           <CommandList>
             <ScrollArea className="h-72">
-              <CommandInput placeholder="Search country..." />
               <CommandEmpty>No country found.</CommandEmpty>
               <CommandGroup>
                 {options


### PR DESCRIPTION
Since there to many countries is better for the search input to sty on top of the popover where we select the country