### PR TITLE
fix issue with cursor behavior in mobile phone-input.tsx

### DIFF
--- a/components/ui/phone-input.tsx
+++ b/components/ui/phone-input.tsx
@@ -43,6 +43,7 @@ const PhoneInput: React.ForwardRefExoticComponent<PhoneInputProps> =
           flagComponent={FlagComponent}
           countrySelectComponent={CountrySelect}
           inputComponent={InputComponent}
+          smartCaret={false}
           /**
            * Handles the onChange event.
            *

--- a/content/snippets/phone-input.mdx
+++ b/content/snippets/phone-input.mdx
@@ -49,6 +49,7 @@ const PhoneInput: React.ForwardRefExoticComponent<PhoneInputProps> =
           flagComponent={FlagComponent}
           countrySelectComponent={CountrySelect}
           inputComponent={InputComponent}
+          smartCaret={false}
           /**
            * Handles the onChange event.
            *


### PR DESCRIPTION
fixed an issue with position of cursor when typing a number in mobile, the cursor goes before the first number entered in the input instead of going behind