### PR TITLE
fix: reset `scroll` position when searching in phone command menu

### DIFF
--- a/components/ui/phone-input.tsx
+++ b/components/ui/phone-input.tsx
@@ -84,6 +84,8 @@ const CountrySelect = ({
   options: countryList,
   onChange,
 }: CountrySelectProps) => {
+  const scrollAreaRef = React.useRef<HTMLDivElement>(null);
+  const [searchValue, setSearchValue] = React.useState("");
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -107,9 +109,25 @@ const CountrySelect = ({
       </PopoverTrigger>
       <PopoverContent className="w-[300px] p-0">
         <Command>
-          <CommandInput placeholder="Search country..." />
+          <CommandInput
+            value={searchValue}
+            onValueChange={(value) => {
+              setSearchValue(value);
+              setTimeout(() => {
+                if (scrollAreaRef.current) {
+                  const viewportElement = scrollAreaRef.current.querySelector(
+                    "[data-radix-scroll-area-viewport]",
+                  );
+                  if (viewportElement) {
+                    viewportElement.scrollTop = 0;
+                  }
+                }
+              }, 0);
+            }}
+            placeholder="Search country..."
+          />
           <CommandList>
-            <ScrollArea className="h-72">
+            <ScrollArea ref={scrollAreaRef} className="h-72">
               <CommandEmpty>No country found.</CommandEmpty>
               <CommandGroup>
                 {countryList.map(({ value, label }) =>


### PR DESCRIPTION
### Before
https://github.com/user-attachments/assets/c5de6210-0e84-42c1-bc80-e0e44262a7f6

### After
https://github.com/user-attachments/assets/a99498aa-1bc3-4c19-baa3-23bcb5f1878f

## Issue
When typing in the search field of the phone command menu, the scroll position doesn't reset to the top, causing users to potentially miss search results that appear at the top of the list.

## Solution
This PR adds functionality to reset the scroll position to the top whenever the search input value changes. It does this by:
1. Adding a ref to the ScrollArea component
2. Finding the actual scrollable viewport element inside the ScrollArea
3. Setting its scrollTop to 0 when the search value changes

## Why this matters
This improves the user experience by ensuring users always see the most relevant search results at the top of the list when they type in the search field.